### PR TITLE
Fix-r-skip-crash-bug

### DIFF
--- a/log.out
+++ b/log.out
@@ -88,3 +88,16 @@
 2025-08-13 15:50:43,818 - INFO - Fundamental frequency detected 112.1779625759876, computing pitch shift
 2025-08-13 15:50:43,818 - INFO - Updating pitch to 15
 >>>>>>> c4c4e2488ae9325168708d9ba8021b3b4f359feb
+2025-08-27 09:41:44,409 - INFO - ------------- logs output to log.out
+2025-08-27 10:13:23,620 - INFO - ------------- logs output to log.out
+2025-08-27 10:13:24,337 - INFO - Fundamental frequency detected 110.31826582581682, computing pitch shift
+2025-08-27 10:13:24,337 - INFO - Updating pitch to 15
+2025-08-27 10:14:22,662 - INFO - ------------- logs output to log.out
+2025-08-27 10:14:22,785 - INFO - Fundamental frequency detected 105.41052323827435, computing pitch shift
+2025-08-27 10:14:22,785 - INFO - Updating pitch to 16
+2025-08-27 10:22:59,595 - INFO - ------------- logs output to log.out
+2025-08-27 10:22:59,712 - INFO - Fundamental frequency detected 103.43713077267104, computing pitch shift
+2025-08-27 10:22:59,712 - INFO - Updating pitch to 17
+2025-08-27 10:24:00,521 - INFO - ------------- logs output to log.out
+2025-08-27 10:24:00,639 - INFO - Fundamental frequency detected 100.16389864642547, computing pitch shift
+2025-08-27 10:24:00,639 - INFO - Updating pitch to 17

--- a/micro_controller.py
+++ b/micro_controller.py
@@ -76,7 +76,7 @@ class POSSIBLESTATES(Enum):
     PLAYREADY = "PLAYREADY"
     PLAYING = "PLAYING"
     PLAYEND = "PLAYEND"
-    INTROFINISHED = "INTROFINISHED"
+    INTROCANCELLED = "INTROCANCELLED"
 
 # Global control flags
 APPSTATE = POSSIBLESTATES.IDLE.value
@@ -371,13 +371,18 @@ def wait_for_intro_to_finish():
     print(f'-------- Exited the while loop, leaving wait_for_intro_to_finish, cancel flag is {cancelFLAG}')
 
     if cancelFLAG:
+        APPSTATE = POSSIBLESTATES.INTROCANCELLED.value
+        print(f'-------- updated APPSTATE to {APPSTATE}')
+    else:
+        print('Intro played until the end, ready to record')
+        send_message(READYTORECORD)
+        APPSTATE = POSSIBLESTATES.RECREADY.value
+
+    if cancelFLAG:
         cancelFLAG = False
 
-    APPSTATE = POSSIBLESTATES.INTROFINISHED.value
-    print(f'-------- updated APPSTATE to {APPSTATE}')
     #send_message(READYTORECORD)
      ## Tell Unreal Engine we are ready to play
-
 
 def play_intro():
     global APPSTATE, POSSIBLESTATES
@@ -442,8 +447,8 @@ def start_hotkeys():
                     #send_message(READYTORECORD)
                     #APPSTATE = POSSIBLESTATES.RECREADY.value
 
-            elif APPSTATE == POSSIBLESTATES.INTROFINISHED.value:
-                print('Intro finished, sending messages')
+            elif APPSTATE == POSSIBLESTATES.INTROCANCELLED.value:
+                print('Intro cancelled, ready to record, sending messages')
                 send_message(READYTORECORD)
                 APPSTATE = POSSIBLESTATES.RECREADY.value
 

--- a/micro_controller.py
+++ b/micro_controller.py
@@ -29,7 +29,7 @@ except AttributeError:
 
 # Configuration
 INACTIVITY_TIMEOUT = 120  # seconds
-WAITFORINFOVIDEOPLAY = 12 # seconds wating for the video
+WAITFORINFOVIDEOPLAY = 10 # seconds wating for the video
 WAITFORINTROVIDEOPLAY = 13
 
 RECORD_SECONDS = 10 # Duration of recording in seconds
@@ -352,9 +352,6 @@ def wait_for_intro_to_finish():
         cancel_event.set()
         print("[x] Intro cancelled by user.")
 
-    def press_r():
-        print('User pressed r, ignoring')
-
     temp_listener = keyboard.GlobalHotKeys({
         '<ctrl>+x': on_cancel,
         'r': on_cancel,
@@ -427,7 +424,7 @@ def inactivity_watcher():
 
 def start_hotkeys():
     global listener, APPSTATE, POSSIBLESTATES
-    print("Press a key to skip the idle state")
+    print("Press PLAY to skip the idle state")
     if listener:
         print("[*] Stopping previous hotkeys listener...")
         listener.stop()
@@ -466,7 +463,7 @@ def start_hotkeys():
                     on_play()
                 elif (order=="record"):
                     send_message(READYTORECORD)
-                    print("[ ] Ready to record again, press Ctrl+R")
+                    print("[ ] Ready to record again, press R")
                     APPSTATE = POSSIBLESTATES.RECREADY.value
                 elif (order=="exit"):
                     APPSTATE = POSSIBLESTATES.IDLE.value

--- a/micro_controller.py
+++ b/micro_controller.py
@@ -440,7 +440,7 @@ def start_hotkeys():
             print(f"-- [ ] Received command: {order}, current state: {APPSTATE}")
             on_activity()
             if APPSTATE == POSSIBLESTATES.IDLE.value:
-                if (order != "record"):
+                if (order == "play"):
                     send_message(PLAYINTRO)
                     APPSTATE = POSSIBLESTATES.INTRO.value
                     play_intro()  

--- a/micro_controller.py
+++ b/micro_controller.py
@@ -351,10 +351,13 @@ def wait_for_intro_to_finish():
         cancel_event.set()
         print("[x] Intro cancelled by user.")
 
+    def press_r():
+        print('User pressed r, ignoring')
+
     temp_listener = keyboard.GlobalHotKeys({
         '<ctrl>+x': on_cancel,
-        'r': on_cancel,
-        '<ctrl>+p': on_cancel
+        'r': press_r,
+        'p': on_cancel
     })
     temp_listener.start()    
 
@@ -364,11 +367,14 @@ def wait_for_intro_to_finish():
         curtime = time.time()
 
     #temp_listener.stop()
+    print(f'-------- Exited the while loop, cancel flag is {cancelFLAG}')
 
     if cancelFLAG:
         cancelFLAG = False
+
     APPSTATE = POSSIBLESTATES.RECREADY.value
-    send_message(READYTORECORD) ## Tell Unreal Engine we are ready to play
+    send_message(READYTORECORD)
+     ## Tell Unreal Engine we are ready to play
 
 
 def play_intro():
@@ -381,9 +387,8 @@ def play_intro():
     wait_thread.start()
     wait_thread.join()
     while APPSTATE != POSSIBLESTATES.RECREADY.value:
-        time.sleep(0.1)    
-    APPSTATE = POSSIBLESTATES.RECREADY.value
-
+        time.sleep(0.05)    
+    #APPSTATE = POSSIBLESTATES.RECREADY.value
 
 def reset_state():
     global APPSTATE, POSSIBLESTATES, last_file_created, listener
@@ -427,12 +432,12 @@ def start_hotkeys():
             print(f"-- [ ] Received command: {order}, current state: {APPSTATE}")
             on_activity()
             if APPSTATE == POSSIBLESTATES.IDLE.value:
-                send_message(PLAYINTRO)
-                APPSTATE = POSSIBLESTATES.INTRO.value
-                play_intro()  
-                send_message(READYTORECORD)
+                if (order != "record"):
+                    send_message(PLAYINTRO)
+                    APPSTATE = POSSIBLESTATES.INTRO.value
+                    play_intro()  
+                    #send_message(READYTORECORD)
             elif APPSTATE == POSSIBLESTATES.RECREADY.value:
-                #on_record()
                 if (order=="record"):
                     on_record()
             elif APPSTATE == POSSIBLESTATES.PLAYREADY.value:
@@ -456,7 +461,7 @@ def start_hotkeys():
                 print(f"[x] Command '{order}' not allowed in state {APPSTATE}.")
             print(f"-- [ ] Finished command, new state: {APPSTATE}")
             print("  R: Record")
-            print("  Ctrl+P: Play last file")
+            print("  P: Play last file")
             print("  Ctrl+X: Cancel recording/playback")
             print("  Ctrl+G: Decrease volume")
             print("  Ctrl+H: Increase volume")    
@@ -465,7 +470,7 @@ def start_hotkeys():
 
     listener = keyboard.GlobalHotKeys({
         'r': dispatcher('record'),
-        '<ctrl>+p': dispatcher('play'),
+        'p': dispatcher('play'),
         '<ctrl>+x': dispatcher('exit'),
         '<ctrl>+g': decrease_system_volume,
         '<ctrl>+h': increase_system_volume,

--- a/micro_controller.py
+++ b/micro_controller.py
@@ -76,6 +76,7 @@ class POSSIBLESTATES(Enum):
     PLAYREADY = "PLAYREADY"
     PLAYING = "PLAYING"
     PLAYEND = "PLAYEND"
+    INTROFINISHED = "INTROFINISHED"
 
 # Global control flags
 APPSTATE = POSSIBLESTATES.IDLE.value
@@ -356,7 +357,7 @@ def wait_for_intro_to_finish():
 
     temp_listener = keyboard.GlobalHotKeys({
         '<ctrl>+x': on_cancel,
-        'r': press_r,
+        'r': on_cancel,
         'p': on_cancel
     })
     temp_listener.start()    
@@ -366,14 +367,15 @@ def wait_for_intro_to_finish():
         time.sleep(0.25)
         curtime = time.time()
 
-    #temp_listener.stop()
-    print(f'-------- Exited the while loop, cancel flag is {cancelFLAG}')
+    temp_listener.stop()
+    print(f'-------- Exited the while loop, leaving wait_for_intro_to_finish, cancel flag is {cancelFLAG}')
 
     if cancelFLAG:
         cancelFLAG = False
 
-    APPSTATE = POSSIBLESTATES.RECREADY.value
-    send_message(READYTORECORD)
+    APPSTATE = POSSIBLESTATES.INTROFINISHED.value
+    print(f'-------- updated APPSTATE to {APPSTATE}')
+    #send_message(READYTORECORD)
      ## Tell Unreal Engine we are ready to play
 
 
@@ -386,8 +388,9 @@ def play_intro():
     wait_thread = threading.Thread(target=wait_for_intro_to_finish)
     wait_thread.start()
     wait_thread.join()
-    while APPSTATE != POSSIBLESTATES.RECREADY.value:
-        time.sleep(0.05)    
+    # while APPSTATE != POSSIBLESTATES.RECREADY.value:
+    #     time.sleep(0.15)
+    #     print('Im only sleeping in play intro')    
     #APPSTATE = POSSIBLESTATES.RECREADY.value
 
 def reset_state():
@@ -437,9 +440,17 @@ def start_hotkeys():
                     APPSTATE = POSSIBLESTATES.INTRO.value
                     play_intro()  
                     #send_message(READYTORECORD)
+                    #APPSTATE = POSSIBLESTATES.RECREADY.value
+
+            elif APPSTATE == POSSIBLESTATES.INTROFINISHED.value:
+                print('Intro finished, sending messages')
+                send_message(READYTORECORD)
+                APPSTATE = POSSIBLESTATES.RECREADY.value
+
             elif APPSTATE == POSSIBLESTATES.RECREADY.value:
                 if (order=="record"):
                     on_record()
+
             elif APPSTATE == POSSIBLESTATES.PLAYREADY.value:
                 if (order=="play"):
                     on_play()
@@ -460,12 +471,12 @@ def start_hotkeys():
             else:
                 print(f"[x] Command '{order}' not allowed in state {APPSTATE}.")
             print(f"-- [ ] Finished command, new state: {APPSTATE}")
-            print("  R: Record")
-            print("  P: Play last file")
-            print("  Ctrl+X: Cancel recording/playback")
-            print("  Ctrl+G: Decrease volume")
-            print("  Ctrl+H: Increase volume")    
-            print("  Ctrl+C: Exit")
+            # print("  R: Record")
+            # print("  P: Play last file")
+            # print("  Ctrl+X: Cancel recording/playback")
+            # print("  Ctrl+G: Decrease volume")
+            # print("  Ctrl+H: Increase volume")    
+            # print("  Ctrl+C: Exit")
         return inner
 
     listener = keyboard.GlobalHotKeys({

--- a/websocket/socketudp.py
+++ b/websocket/socketudp.py
@@ -65,6 +65,7 @@ class SocketUDP():
         logging.debug(f"Message sent")
 
 def send_message(msg):
+    print(f'websocket upd sending message {msg}')
     d = {'type': msg,
         'message': {'data': 1}}
     with SocketUDP("localhost", debug= None) as socket:    


### PR DESCRIPTION
Fixed crashing bug when skipping intro with R. 

Also solved double R issues at record (which involved replacing ctrl+R --> R and ctrl+P --> P and maybe other things ...)

Limited user behaviour by leaving idle only with P

Tested extensively with latest version of Unreal from Aug 25

reduced waiting time to better match video length
WAITFORINFOVIDEOPLAY = 10
